### PR TITLE
feat: Add Tag exclude from archiving

### DIFF
--- a/Suggest/TagSuggest.ts
+++ b/Suggest/TagSuggest.ts
@@ -1,0 +1,21 @@
+import {TFolder} from "obsidian";
+import {TextInputSuggest} from "./suggest";
+
+export class TagSuggest extends TextInputSuggest<string> {
+	getSuggestions(inputStr: string): string[] {
+		// TS ignore is required here because getTags does not exist in the declarations but is a valid function.
+		// Source: https://forum.obsidian.md/t/efficiently-get-all-tags-through-the-api/38400/3
+		// @ts-ignore
+		return Object.keys(app.metadataCache.getTags()).filter((tag: string) => tag.toLowerCase().includes(inputStr.toLowerCase()));
+	}
+
+	renderSuggestion(tag: string, el: HTMLElement): void {
+		el.setText(tag);
+	}
+
+	selectSuggestion(tag: string): void {
+		this.inputEl.value = tag;
+		this.inputEl.trigger("input");
+		this.close();
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "obsidian-sample-plugin",
+	"name": "obsidian-auto-archive",
 	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-sample-plugin",
+			"name": "obsidian-auto-archive",
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
Hi,
I really like your plugin but I thought a setting to exclude a specific tag from archiving would be a neat addition. That way you can keep important note and save it from archiving.